### PR TITLE
Feature to reverse the posts order

### DIFF
--- a/instagram-page-react/package.json
+++ b/instagram-page-react/package.json
@@ -18,6 +18,7 @@
     "redux": "^4.1.1",
     "redux-actions": "^2.6.5",
     "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
     "uid": "^2.0.0",
     "web-vitals": "^1.0.1"
   },

--- a/instagram-page-react/src/pages/profilePage/organisms/posts/Posts.js
+++ b/instagram-page-react/src/pages/profilePage/organisms/posts/Posts.js
@@ -1,5 +1,5 @@
-import React, {useState, useEffect} from 'react';
-import {connect} from "react-redux";
+import React, { useState, useEffect } from 'react';
+import { connect } from "react-redux";
 import PropTypes from 'prop-types';
 
 // lodash
@@ -14,13 +14,12 @@ import Loader from "../../../../atoms/loader";
 import Post from "./molecules/post";
 
 // selectors
-import { getPosts } from "../../reducers/selectors/profilePage.posts";
+import { getReversedPosts } from "../../reducers/selectors/profilePage.posts";
 
 // actionCreators
 import {
     fetchPosts as fetchPostsAction
 } from "../../actions/profilePage.posts";
-
 
 const renderPost = (post) => {
     const{
@@ -59,7 +58,7 @@ function Posts(props) {
 }
 
 const mapStateToProps = (state) => ({
-    posts: getPosts(state),
+    posts: getReversedPosts(state),
 });
 
 const mapDispatchToProps = {

--- a/instagram-page-react/src/pages/profilePage/reducers/selectors/profilePage.posts.js
+++ b/instagram-page-react/src/pages/profilePage/reducers/selectors/profilePage.posts.js
@@ -1,7 +1,11 @@
 import { compose } from 'recompose';
+import { createSelector } from 'reselect'
 
 // lodash
 import _property from 'lodash/property';
+
+// utils
+import immutablyReverse from "../../../../utils/immutablyReverse";
 
 const getProfilePageState = _property('profilePage');
 
@@ -13,4 +17,9 @@ const getPostListState = compose(
 export const getPosts = compose(
     _property('data'),
     getPostListState
+);
+
+export const getReversedPosts = createSelector(
+    [getPosts],
+    immutablyReverse
 );

--- a/instagram-page-react/src/utils/immutablyReverse.js
+++ b/instagram-page-react/src/utils/immutablyReverse.js
@@ -1,0 +1,8 @@
+// lodash
+import _reverse from "lodash/reverse";
+
+const immutablyReverse = (array) => {
+    return _reverse(array?.slice())
+};
+
+export default immutablyReverse;

--- a/instagram-page-react/yarn.lock
+++ b/instagram-page-react/yarn.lock
@@ -9521,6 +9521,11 @@ requires-port@^1.0.0:
   resolved "https://tknon-registry.tekion.xyz/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://tknon-registry.tekion.xyz/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://tknon-registry.tekion.xyz/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
**Problem Statement**

Reverse the list of posts that the page gets from API and then render them

**Approach**

Since we are getting the posts using `Selector` function - `getPosts`, have added an additional parameter in the `getPosts` function to decide the order in which to get the posts from the redux store.

Before:
![Screenshot 2021-08-25 at 12 46 24 PM](https://user-images.githubusercontent.com/87854169/130744079-9558a99e-1486-4720-9285-2244a1e8d730.png)

After:
![Screenshot 2021-08-25 at 12 46 02 PM](https://user-images.githubusercontent.com/87854169/130744115-f41d2018-4e08-418d-be99-9c312be66d5e.png)
